### PR TITLE
Correctly handle duration

### DIFF
--- a/dingo_test.js
+++ b/dingo_test.js
@@ -70,7 +70,7 @@ DingoTest.generateTest = function(args) {
     var clientId = args.client;
     var clientSecret = args.password;
     
-    var testDuration = dingoUtils.parse_argument('int-range', args.testduration, 0);
+    var testDuration = dingoUtils.parse_argument('int-range', args.testduration, 60);
     var testDelay = dingoUtils.parse_argument('int-range', args.testdelay, 60);
     var randomOrder = args.testrandom;
     
@@ -128,7 +128,7 @@ DingoTest.generateTest = function(args) {
         var resource = (args.resource == '*' ? null : args.resource);
         var resourceMatch = args.resourcematch;
         var randomResource = (args.randomresource ? true : (resource == '*' ? true : false));
-        var duration = dingoUtils.parse_argument('int-range', (args.duration ? args.duration : (j.duration ? j.duration : 60)), 60);
+        var duration = dingoUtils.parse_argument('int-range', args.duration, 60);
         if(!type || !operation || !resourceGroup) {
             throw new Error('Required parameters not specified.');
         }


### PR DESCRIPTION
Docs say duration default is 60 and an error in the code for CLI provided params resulted in an error:

var duration = dingoUtils.parse_argument('int-range', (args.duration ? args.duration : (j.duration ? j.duration : 60)), 60);
                                                                                                 ^

TypeError: Cannot read property 'duration' of undefined
    at Function.DingoTest.generateTest (/home/rgardler/projects/chaos-dingo/dingo_test.js:131:98)
    at Object.<anonymous> (/home/rgardler/projects/chaos-dingo/dingo.js:45:22)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:136:18)
    at node.js:963:3
